### PR TITLE
Use native Typescript support of newer Node.js

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,4 @@
 !package.json
 !pnpm-lock.yaml
 !src/
-!docker-entrypoint.sh
-!tsconfig.json
 !LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ===============================
-# 1️⃣ Build stage: Compile the application
+# 1️⃣ Build stage: Install pnpm for dependency installation
 # ===============================
 FROM node:26-alpine AS builder
 WORKDIR /app
@@ -11,16 +11,7 @@ RUN npm install --global corepack@latest && \
 
 # Separate pnpm parts to improve caching and avoid cache invalidation when src changes
 COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
-
-# Copy repo data over and build
-COPY . .
-RUN pnpm run build
-
-# Remove dev dependencies
-RUN rm -rf node_modules && \
-	pnpm i --prod --frozen-lockfile && \
-	pnpm prune --prod
+RUN pnpm install --prod --frozen-lockfile
 
 # ===============================
 # 2️⃣ Runtime stage
@@ -28,9 +19,14 @@ RUN rm -rf node_modules && \
 FROM gcr.io/distroless/nodejs26-debian13
 WORKDIR /app
 
-# Copy built files from builder
-COPY --from=builder /app/dist ./dist
+# Copy basic package information
+COPY LICENSE package.json ./
+
+# Copy code from local to image (no transpilation needed thanks to native TS support)
+COPY ./src ./src
+
+# Copy runtime dependencies from builder
 COPY --from=builder /app/node_modules ./node_modules
 
-ENTRYPOINT ["/nodejs/bin/node", "/app/dist/index.js"]
+ENTRYPOINT ["/nodejs/bin/node", "/app/src/index.ts"]
 CMD ["--config", "/config/config.jsonc"]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Alexander Voglsperger",
   "license": "MIT",
   "description": "Dynamic DNS using domain hosted on Cloudflare ",
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "type": "module",
   "scripts": {
     "build": "tsc",
@@ -27,7 +27,7 @@
     "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=18",
+    "node": ">=24.12 || >=26.0",
     "deno": ">=1.28"
   },
   "packageManager": "pnpm@11.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsflare",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "Alexander Voglsperger",
   "license": "MIT",
   "description": "Dynamic DNS using domain hosted on Cloudflare ",

--- a/src/CF/Cloudflare.ts
+++ b/src/CF/Cloudflare.ts
@@ -3,8 +3,8 @@
  * See LICENSE in the project root for license information.
  */
 import { AxiosHeaders } from "axios";
-import type * as CF_T from "./CloudflareTypes.js";
-import { AxiosInstance } from "../WebReq.js";
+import type * as CF_T from "./CloudflareTypes.ts";
+import { AxiosInstance } from "../WebReq.ts";
 
 // -----------------------------------------------------------------------------
 /**

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -2,8 +2,8 @@
  * Copyright © 2025-2026 Alexander Voglsperger. Licensed under the MIT License.
  * See LICENSE in the project root for license information.
  */
-import * as path from "path";
-import * as fsp from "fs/promises";
+import * as path from "node:path";
+import * as fsp from "node:fs/promises";
 
 const AUTO_TTL = 1;
 const MIN_TTL = 60;

--- a/src/WebReq.ts
+++ b/src/WebReq.ts
@@ -3,7 +3,7 @@
  * See LICENSE in the project root for license information.
  */
 
-import axios, { AxiosError, AxiosHeaders, AxiosRequestConfig } from "axios";
+import axios, { AxiosError, AxiosHeaders, type AxiosRequestConfig } from "axios";
 
 export const AxiosInstance = axios.create({
 	timeout: 5000,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,10 @@
  * Copyright © 2025-2026 Alexander Voglsperger. Licensed under the MIT License.
  * See LICENSE in the project root for license information.
  */
-import path from "path";
-import { Cloudflare } from "./CF/Cloudflare.js";
-import { EmailKeyItem, loadConfig, TokenItem } from "./Config.js";
-import { AxiosInstance } from "./WebReq.js";
+import path from "node:path";
+import { Cloudflare } from "./CF/Cloudflare.ts";
+import { type EmailKeyItem, loadConfig, type TokenItem } from "./Config.ts";
+import { AxiosInstance } from "./WebReq.ts";
 
 // -----------------------------------------------------------------------------
 interface IpifyResponse {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"types": ["node"],
-		"outDir": "dist",
+		"noEmit": true,
 		"rootDir": "src",
 		"esModuleInterop": true,
 		"strict": true,
@@ -10,19 +10,17 @@
 		"noImplicitAny": true,
 		"strictNullChecks": true,
 		"strictPropertyInitialization": true,
-		"sourceMap": true,
-		"incremental": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"noFallthroughCasesInSwitch": true,
 		"noImplicitReturns": true,
-		"removeComments": true,
 		"allowJs": false,
 		"noUncheckedIndexedAccess": true,
 		"allowUnreachableCode": false,
 		"allowUnusedLabels": false,
 		"forceConsistentCasingInFileNames": true,
-		"pretty": true
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": true
 	},
 	"include": [
 		"src/**/*"


### PR DESCRIPTION
Node.js supports loading `.ts` files via type stripping for some time now. Use that to avoid transpilation into `.js`.

This bumps minimum version to at least Node.js v24.12 or Node.js 26. 